### PR TITLE
The output of jail::image fetch in jail::create should be displayed

### DIFF
--- a/lib/jailer-core
+++ b/lib/jailer-core
@@ -345,7 +345,7 @@ jail::create(){
     else
       _version=$(uname -r)
       _version=${_version%%-p*}
-      jail::image list ${_version} >/dev/null || jail::image fetch >/dev/null
+      jail::image list ${_version} >/dev/null || jail::image fetch
     fi
   fi
 


### PR DESCRIPTION
When the user tries to create a jail which has a missing version, Jailer tries to automatically fetch the image, however, the output is sent to /dev/null. In reality, the user should be aware that Jailer is trying to fetch the image, otherwise it might stay "hanging" for a long time, specially if the user has a bad connection.